### PR TITLE
Injecting descriptions from csvs into M_Schema

### DIFF
--- a/server/utilities/utility_functions.py
+++ b/server/utilities/utility_functions.py
@@ -200,7 +200,7 @@ def format_schema(format_type: FormatType, db_path: str, matches=None):
         elif format_type == FormatType.M_SCHEMA:
             db_name=db_path.split('/')[-1].rstrip('.sqlite')
             db_engine=create_engine(f'sqlite:///{db_path}')
-            schema_engine= SchemaEngine(engine=db_engine, db_name=db_name, matches=matches)
+            schema_engine= SchemaEngine(engine=db_engine, db_name=db_name, matches=matches, db_path = db_path)
             mschema = schema_engine.mschema
             mschema_str = mschema.to_mschema()
             return mschema_str


### PR DESCRIPTION
## Description

M_Schema now has column and table descriptions from the csv files for each db. This is only for the target question and not shots. 

pass Schema_Engine the db_path to get the descriptions, None otherwise
