### PR TITLE
Fix: Ensure Complete Vector Store Population in ChromaDB

### DIFF
--- a/server/utilities/vectorize.py
+++ b/server/utilities/vectorize.py
@@ -59,10 +59,10 @@ def make_samples_collection():
     collection_name = ""
 
     # Check if collection already exists
-    if PATH_CONFIG.dataset_dir != PATH_CONFIG.sample_dataset_type:
+    if PATH_CONFIG.dataset_type != PATH_CONFIG.sample_dataset_type:
         collection_name = "unmasked_data_samples"
 
-    elif PATH_CONFIG.dataset_dir == PATH_CONFIG.sample_dataset_type:
+    elif PATH_CONFIG.dataset_type == PATH_CONFIG.sample_dataset_type:
         database_name = PATH_CONFIG.database_name
         collection_name = f"{database_name}_unmasked_data_samples"
 


### PR DESCRIPTION
## Description
This PR corresponds to the following [Task](https://www.notion.so/conradlabshq/Ensure-Complete-Vector-Store-Population-in-ChromaDB-1a6512441d3c80f39aaaef03decfa5c3?pvs=4).

Previously, the make_samples_collection function would detect an existing collection and skip data insertion, leading to an incomplete vector store if the script failed midway.

Changes:
- Removed batch processing to prevent partial insertions.
- Now, collection.add() is executed fully or not at all. 