### PR TITLE
Refactor: Group SQL Candidates by Results Before Selection

### DIFF
--- a/server/utilities/candidate_selection.py
+++ b/server/utilities/candidate_selection.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+import hashlib
 from utilities.config import PATH_CONFIG
 from utilities.constants.prompts_enums import FormatType
 from utilities.utility_functions import format_schema
@@ -12,12 +14,13 @@ import time
 
 logger = setup_logger(__name__)
 
-def xiyan_basic_llm_selector(sqls_with_config,target_question, client, database, pruned_schema, evidence=None):
 
-    # if sqls the same then return the first one
-    sqls = [i[0] for i in sqls_with_config]
-    if len(set(sqls)) == 1:
-        return [sqls[0], sqls_with_config[0][1]]
+def hash_result(result):
+    """Generate a hash for SQL results."""
+    return hashlib.md5(str(result).encode()).hexdigest()
+
+def xiyan_basic_llm_selector(sqls_with_config,target_question, client, database, pruned_schema, evidence=None):
+    """ Select SQL from a list of sqls using XiYan Selector"""
 
     connection = sqlite3.connect(
         PATH_CONFIG.sqlite_path(database_name=database)
@@ -26,23 +29,48 @@ def xiyan_basic_llm_selector(sqls_with_config,target_question, client, database,
 
     schema = format_schema(format_type=FormatType.M_SCHEMA,database_name=database, matches=pruned_schema)
     
-    prompt_prefix = XIYAN_CANIDADATE_SELECTION_PREFIX.format(candidate_num=len(sqls), schema = schema, evidence = evidence, question = target_question)
-
     candidate_dict = {}
     sql_dict = {}
     idx_dict = {}
-    for idx, sql in enumerate(sqls):
+
+    # Group SQLs by their results using a hash
+    result_groups = defaultdict(list)
+
+    for idx, (sql, config_id) in enumerate(sqls_with_config):
         try:
-            res = cursor.execute(sql)
+            cursor.execute(sql)
             res = cursor.fetchall()
-            if not isinstance(res, RuntimeError):
+            result_hash = hash_result(res)
+
+            # Only consider top 10 results 
+            if res:
                 res = res[:10]
+
         except Exception as e:
             res = str(e)
-        candidate_id = chr(idx+65)
-        candidate_dict[candidate_id]=XIYAN_CANDIDATE_PROMPT.format(candidate_id = candidate_id, sql = sql, execution_result = res)
+            result_hash = hash_result(res)
+
+        if result_hash not in result_groups:
+            result_groups[result_hash] = []
+        result_groups[result_hash].append((sql, config_id, res)) 
+
+    # Select one SQL from each unique result group
+    selected_sqls_with_config = [group[0] for group in result_groups.values()]  
+
+    # If only one SQL is left, return it
+    if len(selected_sqls_with_config) == 1:
+        return selected_sqls_with_config[0][0], selected_sqls_with_config[0][1]
+
+    # Rebuild candidate list for selection
+    for idx, (sql, config_id, res) in enumerate(selected_sqls_with_config):
+        candidate_id = chr(idx + 65)
+        candidate_dict[candidate_id] = XIYAN_CANDIDATE_PROMPT.format(
+            candidate_id=candidate_id, sql=sql, execution_result=res
+        )
         sql_dict[candidate_id] = sql
-        idx_dict[candidate_id] = sqls_with_config[idx][1]
+        idx_dict[candidate_id] = config_id
+
+    prompt_prefix = XIYAN_CANIDADATE_SELECTION_PREFIX.format(candidate_num=len(selected_sqls_with_config), schema = schema, evidence = evidence, question = target_question)
 
     cand_ids_suffix = ' or '.join([f"\"{i}\"" for i in list(candidate_dict.keys())])
     suffix = "\nPlease output the selected candidate as " + cand_ids_suffix+' and nothing else.'


### PR DESCRIPTION
## Description

This PR corresponds to the following [Group SQL Candidates by Results Before Selection](https://www.notion.so/conradlabshq/Group-SQL-Candidates-by-Results-Before-Selection-1b2512441d3c804ba8f7d0b0dffd421c?pvs=4)

Group SQL candidates by SQL result's hash to reduce redundancy in XiYan Selection Prompt.





