### PR TITLE
Refactor: Use Longest Column Descriptions in Format Schemas

### DIFF
--- a/server/utilities/m_schema/schema_engine.py
+++ b/server/utilities/m_schema/schema_engine.py
@@ -88,8 +88,8 @@ class SchemaEngine(SQLDatabase):
                         df["original_column_name"].str.lower().str.strip(),
                         df.apply(
                             lambda row: max(
-                                row.get('improved_column_description', ''),
-                                row.get('column_description', ''),
+                                str(row.get('improved_column_description', '')),
+                                str(row.get('column_description', '')),
                                 key=len
                             ).strip("\n"),
                             axis=1

--- a/server/utilities/m_schema/schema_engine.py
+++ b/server/utilities/m_schema/schema_engine.py
@@ -83,7 +83,20 @@ class SchemaEngine(SQLDatabase):
         for table in self.table_descriptions.keys():
             try:
                 df = pd.read_csv(f"{description_dir}/{table}.csv")
-                col_desc = dict(zip(df["original_column_name"].str.lower().str.strip(), df["improved_column_description"]))
+                col_desc = dict(
+                    zip(
+                        df["original_column_name"].str.lower().str.strip(),
+                        df.apply(
+                            lambda row: max(
+                                row.get('improved_column_description', ''),
+                                row.get('column_description', ''),
+                                key=len
+                            ).strip("\n"),
+                            axis=1
+                        )
+                    )
+                )
+
                 self.column_descriptions[table] = col_desc
             except FileNotFoundError:
                 continue

--- a/server/utilities/utility_functions.py
+++ b/server/utilities/utility_functions.py
@@ -256,9 +256,12 @@ def format_schema(format_type: FormatType, database_name: str=None, matches=None
                                     if pd.notna(row["data_format"])
                                     else ""
                                 )
-                                column_description = row[
-                                    "improved_column_description"
-                                ].strip("\n")
+
+                                column_description = max(
+                                    str(row.get('improved_column_description', '')),
+                                    str(row.get('column_description', '')),
+                                    key=len
+                                ).strip("\n")
 
                                 # Get first row as example
                                 query = f'SELECT "{column_name}" FROM "{table_name}" LIMIT 1'

--- a/server/utilities/utility_functions.py
+++ b/server/utilities/utility_functions.py
@@ -257,11 +257,9 @@ def format_schema(format_type: FormatType, database_name: str=None, matches=None
                                     else ""
                                 )
 
-                                column_description = max(
-                                    str(row.get('improved_column_description', '')),
-                                    str(row.get('column_description', '')),
-                                    key=len
-                                ).strip("\n")
+                                column_description = row[
+                                    "improved_column_description"
+                                ].strip("\n")
 
                                 # Get first row as example
                                 query = f'SELECT "{column_name}" FROM "{table_name}" LIMIT 1'


### PR DESCRIPTION
## Description
This PR corresponds to the following [Task](https://www.notion.so/conradlabshq/Use-Longest-Column-Descriptions-in-Format-Schemas-1c1512441d3c801ba8c7da7f93b0fe01?pvs=4).

This update enhances the column descriptions used across all format schemas by selecting the longer description between:
- The BIRD Dev dataset (from the new column meaning file).
- The improved LLM-generated description.

Changes include updating `schema_engine.py` and the `format_schema()`method in `utility_functions.py` to select the longer column description.

Validated the changes on the following FormatTypes:
- semantic
- m_schema