### PR TITLE
Feat: Add Gemini 2.5 Pro Experimental model

### DIFF
--- a/server/utilities/constants/LLM_enums.py
+++ b/server/utilities/constants/LLM_enums.py
@@ -37,6 +37,7 @@ class ModelType(Enum):
     GOOGLEAI_GEMINI_2_0_FLASH_THINKING_EXP_0121 = "gemini-2.0-flash-thinking-exp-01-21"
     GOOGLEAI_GEMINI_2_0_FLASH_LITE_PREVIEW_0205 = "gemini-2.0-flash-lite-preview-02-05"
     GOOGLEAI_GEMINI_2_0_PRO_EXP = "gemini-2.0-pro-exp-02-05"
+    GOOGLEAI_GEMINI_2_5_PRO_EXP = "gemini-2.5-pro-exp-03-25"
     # Fine Tuned Models
     GOOGLEAI_GEMINI_1_5_FLASH_SCHEMA_PRUNING_FT = "tunedModels/pruneschema3305samples-34bzckir3jfw"
 
@@ -92,6 +93,7 @@ VALID_LLM_MODELS = {
         ModelType.GOOGLEAI_GEMINI_2_0_FLASH_THINKING_EXP_0121,
         ModelType.GOOGLEAI_GEMINI_2_0_FLASH_LITE_PREVIEW_0205,
         ModelType.GOOGLEAI_GEMINI_2_0_PRO_EXP,
+        ModelType.GOOGLEAI_GEMINI_2_5_PRO_EXP,
         ModelType.GOOGLEAI_GEMINI_1_5_FLASH_SCHEMA_PRUNING_FT
     ],
     LLMType.DEEPSEEK: [

--- a/server/utilities/llm_metrics/pricing.py
+++ b/server/utilities/llm_metrics/pricing.py
@@ -73,6 +73,10 @@ PRICING = {
             "input": 0.0, # free for now
             "output": 0.0,
         },
+        ModelType.GOOGLEAI_GEMINI_2_5_PRO_EXP: {
+            "input": 0.0, # free for now
+            "output": 0.0,
+        },
         ModelType.GOOGLEAI_GEMINI_1_5_FLASH_SCHEMA_PRUNING_FT: {
             "input": 0.00035,
             "output": 0.0015,


### PR DESCRIPTION
## Description

This PR corresponds to the following [Task](https://www.notion.so/conradlabshq/Add-Gemini-2-5-Pro-Experimental-Model-1c3512441d3c80968edcf149aa1b0a3f?pvs=4).

This update integrates the Gemini 2.5 Pro Experimental model into the codebase. Specifically:
- Added Gemini 2.5 Pro Experimental to `ModelType` and `VALID_LLM_MODELS` in `llm_enum.py.`
- Updated `llm_metrics/pricing.py` to reflect that the model is currently free.