### PR TITLE
Bird Eval Path Config Fix

### DIFF
--- a/server/scripts/bird_eval.py
+++ b/server/scripts/bird_eval.py
@@ -45,7 +45,7 @@ def execute_model(predicted_sql,ground_truth, db_place, idx, meta_time_out):
         result = [(f'timeout',)]
         res = 0
     except Exception as e:
-        split_dir=db_place.split('/')
+        split_dir=str(db_place).split('/')
         db=split_dir[-1][:-7]
         result = [(f'error',)]  # possibly len(query) > 512 or not executable
         res = 0


### PR DESCRIPTION
## Description

On error in SQL Query previous bird_eval threw an error due to this:
`split_dir=db_place.split('/')`

Here db_place is a POSIX path as returned in the updated Path_Config and not a string. Hence, .split was not an attribute of db_place. 
