### PR TITLE
Feat(Schema Linking): Include Referenced Foreign Key Columns in Pruned Schema

### DIFF
--- a/server/utilities/constants/response_messages.py
+++ b/server/utilities/constants/response_messages.py
@@ -46,6 +46,7 @@ ERROR_UNSUPPORTED_FORMAT_TYPE = "Unsupported format type: {format_type}"
 ERROR_FAILED_FETCH_TABLE_NAMES = "Failed to fetch table names: {error}"
 ERROR_FAILED_FETCH_COLUMN_NAMES = "Failed to fetch column names: {error}"
 ERROR_FAILED_FETCH_SCHEMA = "Failed to fetch schema: {error}"
+ERROR_FAILED_FETCH_FOREIGN_KEYS = "Failed to fetch foreign keys for table {table_name}: {error}"
 
 # Cost Estimation related Errors
 ERROR_INVALID_MODEL_FOR_TOKEN_ESTIMATION = "Model {model} is not a valid OpenAI model. Only OpenAI models are supported."

--- a/server/utilities/utility_functions.py
+++ b/server/utilities/utility_functions.py
@@ -19,7 +19,8 @@ from utilities.constants.response_messages import (
     ERROR_UNSUPPORTED_FORMAT_TYPE,
     ERROR_FAILED_FETCH_COLUMN_NAMES,
     ERROR_FAILED_FETCH_TABLE_NAMES,
-    ERROR_FAILED_FETCH_SCHEMA
+    ERROR_FAILED_FETCH_SCHEMA,
+    ERROR_FAILED_FETCH_FOREIGN_KEYS
 )
 
 from utilities.constants.LLM_enums import LLMType, ModelType, VALID_LLM_MODELS
@@ -122,6 +123,27 @@ def get_table_columns(connection: sqlite3.Connection, table_name: str):
     except Exception as e:
         raise RuntimeError((ERROR_FAILED_FETCH_COLUMN_NAMES.format(error=str(e))))
 
+
+def get_table_foreign_keys(connection: sqlite3.Connection, table_name: str):
+    """
+    Retrieves foreign key information for a given table.
+    """
+    try:
+        query = f'PRAGMA foreign_key_list("{table_name}");'
+        cursor = connection.execute(query)
+        foreign_keys = cursor.fetchall()
+
+        return [
+            {
+                "from_column": row[3],   # column in current table
+                "to_column": row[4],     # referenced column in foreign table
+                "to_table": row[2]   # referenced table
+            }
+            for row in foreign_keys
+        ]
+    
+    except Exception as e:
+        raise RuntimeError(ERROR_FAILED_FETCH_FOREIGN_KEYS.format(table_name=table_name, error=str(e)))
 
 def get_array_of_table_and_column_name(database_path: str):
     try:


### PR DESCRIPTION
## Description

This PR corresponds to the following [Task](https://www.notion.so/conradlabshq/Enhance-Schema-Pruning-by-Including-Foreign-Key-Dependencies-1d1512441d3c804fa5cdf5970cc8811b?pvs=4)

The goal of this task was to minimise the missing_elements score when linking schema elements.
To achieve this, I added a utility function to include the referenced foreign key columns in the schema. 

The following changes were introduced:
- Created helper function `get_table_foreign_keys()` to fetch foreign key information for a table.
- Created `include_referenced_fk_columns_in_schema()` to include referenced foreign key columns into the pruned schema.

The result of adding this function in our pipeline:
- missing_score improved from 8.8% → 7.5%
- However, prune_score dropped from 92% → 90%

Since we still need to evaluate different techniques before finalising the approach, I have not yet integrated these functions into the main pipeline.

Accuracy Details:
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/6994d981-ea27-4628-b3a3-863c56141bb5" />
