### PR TITLE
Feat: Add Gemini 2.5 Pro Preview and Flash Preview 

### DIFF
--- a/server/utilities/constants/LLM_enums.py
+++ b/server/utilities/constants/LLM_enums.py
@@ -38,6 +38,8 @@ class ModelType(Enum):
     GOOGLEAI_GEMINI_2_0_FLASH_LITE_PREVIEW_0205 = "gemini-2.0-flash-lite-preview-02-05"
     GOOGLEAI_GEMINI_2_0_PRO_EXP = "gemini-2.0-pro-exp-02-05"
     GOOGLEAI_GEMINI_2_5_PRO_EXP = "gemini-2.5-pro-exp-03-25"
+    GOOGLEAI_GEMINI_2_5_PRO_PREVIEW = "gemini-2.5-pro-preview-03-25"
+    GOOGLEAI_GEMINI_2_5_FLASH_PREVIEW = "gemini-2.5-flash-preview-04-17"
     # Fine Tuned Models
     GOOGLEAI_GEMINI_1_5_FLASH_SCHEMA_PRUNING_FT = "tunedModels/pruneschema3305samples-34bzckir3jfw"
 
@@ -94,6 +96,8 @@ VALID_LLM_MODELS = {
         ModelType.GOOGLEAI_GEMINI_2_0_FLASH_LITE_PREVIEW_0205,
         ModelType.GOOGLEAI_GEMINI_2_0_PRO_EXP,
         ModelType.GOOGLEAI_GEMINI_2_5_PRO_EXP,
+        ModelType.GOOGLEAI_GEMINI_2_5_PRO_PREVIEW,
+        ModelType.GOOGLEAI_GEMINI_2_5_FLASH_PREVIEW,
         ModelType.GOOGLEAI_GEMINI_1_5_FLASH_SCHEMA_PRUNING_FT
     ],
     LLMType.DEEPSEEK: [

--- a/server/utilities/llm_metrics/pricing.py
+++ b/server/utilities/llm_metrics/pricing.py
@@ -77,6 +77,14 @@ PRICING = {
             "input": 0.0, # free for now
             "output": 0.0,
         },
+        ModelType.GOOGLEAI_GEMINI_2_5_PRO_PREVIEW: {    
+            "input": 0.00125, # Asumption: prompts <= 200k tokens
+            "output": 0.01, # Asumption: prompts <= 200k tokens
+        },
+        ModelType.GOOGLEAI_GEMINI_2_5_FLASH_PREVIEW: {
+            "input": 0.00015,
+            "output": 0.0006, # Asumption: model is Non-thinking
+        },
         ModelType.GOOGLEAI_GEMINI_1_5_FLASH_SCHEMA_PRUNING_FT: {
             "input": 0.00035,
             "output": 0.0015,


### PR DESCRIPTION
## Description

This PR corresponds to the following [Add Gemini 2.5 Pro Preview and Flash Preview ](https://www.notion.so/conradlabshq/Add-Gemini-2-5-Pro-Preview-and-Flash-Preview-1d9512441d3c80988971e9573fe1dd21?pvs=4)

This PR adds support for Gemini 2.5 Pro Preview and Gemini 2.5 Flash Preview by extending the `ModelType` enum and registering them as valid models under the Google AI provider.
