### PR TITLE
Feat Add Support for OpenAI o4-mini and o3 Models

### DIFF
--- a/server/utilities/constants/LLM_enums.py
+++ b/server/utilities/constants/LLM_enums.py
@@ -17,6 +17,8 @@ class ModelType(Enum):
     OPENAI_GPT4_O = "gpt-4o-2024-08-06"
     OPENAI_GPT4_O_MINI = "gpt-4o-mini-2024-07-18"
     OPENAI_O1 = "o1"
+    OPENAI_O3 = "o3"
+    OPENAI_O4_MINI = "o4-mini"
     OPENAI_O3_MINI = "o3-mini"
     OPENAI_O1_MINI = "o1-mini"
 
@@ -76,6 +78,8 @@ VALID_LLM_MODELS = {
         ModelType.OPENAI_GPT4_O,
         ModelType.OPENAI_GPT4_O_MINI,
         ModelType.OPENAI_O1,
+        ModelType.OPENAI_O3,
+        ModelType.OPENAI_O4_MINI,
         ModelType.OPENAI_O3_MINI,
         ModelType.OPENAI_O1_MINI
     ],

--- a/server/utilities/llm_metrics/pricing.py
+++ b/server/utilities/llm_metrics/pricing.py
@@ -35,6 +35,14 @@ PRICING = {
             "input": 0.015,
             "output": 0.06,
         },
+        ModelType.OPENAI_O3: { 
+            "input": 0.01,
+            "output": 0.04,
+        },
+        ModelType.OPENAI_O4_MINI: {
+            "input": 0.0011,
+            "output": 0.0044,
+        },
         ModelType.OPENAI_O3_MINI: {
             "input": 0.0011,
             "output": 0.0044,


### PR DESCRIPTION
## Description

This PR corresponds to the following [Task](https://www.notion.so/conradlabshq/Add-o4-mini-and-o3-to-the-Codebase-1dc512441d3c8023a9b4d6f6eee352f8?pvs=4)
Adds support for OpenAI's o4-mini and o3 models to the codebase. 
This includes:
- Adding both models to the ModelType enum.
- Registering them as valid OpenAI models.
- Updating pricing with appropriate cost details.
