### PR TITLE
Backward Schema Linking With Internal Prompts

### DIFF
--- a/server/utilities/schema_linking/schema_linking_utils.py
+++ b/server/utilities/schema_linking/schema_linking_utils.py
@@ -228,7 +228,7 @@ def backward_schema_linking(
         database_name=database_name,
     )
 
-    if client == None:
+    if client is None:
         model = [LLMType.GOOGLE_AI, ModelType.GOOGLEAI_GEMINI_2_5_PRO_PREVIEW]
         client = ClientFactory.get_client(
             *model,
@@ -236,8 +236,8 @@ def backward_schema_linking(
             max_tokens=8192,
         )
 
-    dummy_sql_unformatted = client.execute_prompt(prompt=dummy_sql_prompt)
-    dummy_sql_formatted = format_sql_response(dummy_sql_unformatted)
-    schema_used = get_sql_columns_dict(db_path=database_name, sql=dummy_sql_formatted)
+    unformatted_dummy_sql = client.execute_prompt(prompt=dummy_sql_prompt)
+    formatted_dummy_sql = format_sql_response(unformatted_dummy_sql)
+    dummy_sql_schema_used = get_sql_columns_dict(db_path=database_name, sql=formatted_dummy_sql)
 
-    return schema_used
+    return dummy_sql_schema_used

--- a/server/utilities/utility_functions.py
+++ b/server/utilities/utility_functions.py
@@ -7,7 +7,7 @@ from enum import Enum
 import concurrent.futures
 import pandas as pd
 import yaml
-
+from typing import Dict, List
 from utilities.constants.response_messages import (
     ERROR_DATABASE_QUERY_FAILURE,
     ERROR_SQL_QUERY_REQUIRED,
@@ -17,6 +17,8 @@ from utilities.constants.response_messages import (
     ERROR_UNSUPPORTED_FORMAT_TYPE,
     ERROR_FAILED_FETCH_COLUMN_NAMES,
     ERROR_FAILED_FETCH_TABLE_NAMES,
+    ERROR_FAILED_FETCH_FOREIGN_KEYS,
+    ERROR_FAILED_FETCH_SCHEMA,
 )
 
 from utilities.constants.LLM_enums import LLMType, ModelType, VALID_LLM_MODELS
@@ -120,6 +122,52 @@ def get_table_columns(connection: sqlite3.Connection, table_name: str):
         raise RuntimeError((ERROR_FAILED_FETCH_COLUMN_NAMES.format(error=str(e))))
 
 
+def get_table_foreign_keys(connection: sqlite3.Connection, table_name: str):
+    """
+    Retrieves foreign key information for a given table.
+    """
+    try:
+        query = f'PRAGMA foreign_key_list("{table_name}");'
+        cursor = connection.execute(query)
+        foreign_keys = cursor.fetchall()
+
+        return [
+            {
+                "from_column": row[3],   # column in current table
+                "to_column": row[4],     # referenced column in foreign table
+                "to_table": row[2]   # referenced table
+            }
+            for row in foreign_keys
+        ]
+    
+    except Exception as e:
+        raise RuntimeError(ERROR_FAILED_FETCH_FOREIGN_KEYS.format(table_name=table_name, error=str(e)))
+
+def get_primary_keys(connection: sqlite3.Connection) -> Dict[str, List[str]]:
+    """
+    Returns a dictionary mapping each table name to its list of primary key columns.
+    """
+    try:
+        cursor = connection.cursor()
+        pk_dict = {}
+        # Get all table names
+        tables = get_table_names(connection)
+        if 'sqlite_sequence' in tables:
+            tables.remove('sqlite_sequence')
+
+        for table_name in tables:
+            cursor.execute(f"PRAGMA table_info(\"{table_name}\");")
+            columns = cursor.fetchall()
+
+            # PRAGMA table_info returns: cid, name, type, notnull, dflt_value, pk
+            pk_columns = [col[1] for col in columns if col[5] > 0]  # col[1] is column name, col[5] is pk flag
+            pk_dict[table_name] = pk_columns
+
+        return pk_dict
+    except Exception as e:
+        raise RuntimeError(ERROR_FAILED_FETCHING_PRIMARY_KEYS.format(error=str(e)))
+
+
 def get_array_of_table_and_column_name(database_path: str):
     try:
         connection = sqlite3.connect(database_path)
@@ -133,6 +181,34 @@ def get_array_of_table_and_column_name(database_path: str):
         return table_names + column_names
     finally:
         connection.close()
+
+
+def get_schema_dict(database_path: str) -> Dict[str, List[str]]:
+    """
+    Retrieves schema dictionary from the SQLite database in the format {table_name: [column1, column2, ...]}.
+    """
+
+    try:
+
+        with sqlite3.connect(database_path) as connection:
+
+            connection.row_factory = sqlite3.Row
+
+            table_names = get_table_names(connection)
+
+            schema = {
+                table_name: get_table_columns(connection, table_name)
+                for table_name in table_names
+            }
+
+            if "sqlite_sequence" in schema:
+                del schema['sqlite_sequence']
+
+            return schema
+
+    except Exception as e:
+
+        raise RuntimeError(ERROR_FAILED_FETCH_SCHEMA.format(error=str(e)))
 
 
 def prune_code(ddl, columns, connection, table):


### PR DESCRIPTION
### Description

This pull request addresses the following [Backward Schema Linking With Internal Prompts](https://www.notion.so/conradlabshq/Experiment-with-Backward-Schema-Linking-Approach-for-Improving-Prune-Score-1d1512441d3c8008ad4dd5de16d83479?pvs=4)

The primary goal of this PR is to integrate a **backward schema linking** approach into the `schema_linking_utils` module.

### Key Additions
- Introduced a new function: `backward_schema_linking(target_question, evidence, database_name, prompt_type, client)`
- This function generates a dummy SQL query using the full database schema and a specified prompt type (default: *Code Representation*).
- The schema elements referenced in the dummy SQL are extracted and returned as the **pruned schema**.
- The `utility_functions.py` file is also updated to reflect changes from the TA SQL branch.


### For Reviewers
Please do not review the utility_functions file as it is part of the TA-SQL Integration branch. The reason for adding it here was so we avoid merge conflicts in the next merge. 

This approach helps determine which parts of the schema are relevant to a question, improving pruning accuracy.
